### PR TITLE
Enable automatic tournament matches

### DIFF
--- a/backend/routes/tournaments.js
+++ b/backend/routes/tournaments.js
@@ -156,7 +156,17 @@ router.get('/:id/leaderboard', async (req, res) => {
       return b.totalScore - a.totalScore;
     });
 
-    res.json(leaderboard);
+  res.json(leaderboard);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// GET /api/tournaments/match/:matchId/replay - Obtenir le replay d'un match
+router.get('/match/:matchId/replay', async (req, res) => {
+  try {
+    const data = await TournamentService.getMatchReplay(req.params.matchId);
+    res.json(data);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
## Summary
- run all phases and matches when a tournament is started
- expose replay data through a new tournament route

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3805e4b88331b66b776bc715cb8a